### PR TITLE
Allow dynamic polling based on game-state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs)
 # Home Assistant NHL API
-NHL Stats API Integration Into Home Assistant
+NHL Stats API Integration Into Home Assistant: Bring live score updates into Home Assistant and fire automations when your team scores!
+
+<span style="color:red">*New!*</span> The sensor will only fetch data every 10 minutes when the game is not live and will then update at the user defined frequency (or every second if undefined) once the game is live.
 ## Installation: Manual
 1. Copy the `nhl_api` folder to the `custom_components` folder in your Home Assistant configuration directory.
 2. From the [teams.md](https://github.com/JayBlackedOut/hass-nhlapi/blob/master/teams.md) file in this repository, find the team_id of the team you would like to track.
@@ -30,9 +32,9 @@ sensor:
 | platform | true     | string  | `nhl_api`                                                                                                                           |
 | team_id  | true     | integer | Identifies the team to be tracked by the sensor. See [teams.md](https://github.com/JayBlackedOut/hass-nhlapi/blob/master/teams.md). |
 | name     | false    | string  | Friendly name of the sensor. If not defined, defaults to: 'NHL Sensor'.                                                             |
-| scan_interval | false    | integer  | Number of seconds until the sensor updates its state. If not defined, defaults to 5 seconds.                                                             |
+| scan_interval | false    | integer  | Number of seconds until the sensor updates its state when the game is live. If not defined, defaults to 1 second.                                                             |
 
-Warning! Setting your `scan_interval` to a low number leads to more writes to your disk. It is recommended to not set the scan interval to less than 5 if running Home Assistant on a Raspberry Pi. Also, each time the sensor updates (i.e. at each scan interval), anywhere from ~300B to ~25KB of data is consumed. Keep this in mind if you have a low internet data cap.
+<span style="color:red">*Warning!*</span> Setting your `scan_interval` to a low number leads to more writes to your disk. It is recommended to not set the scan interval to less than 5 if running Home Assistant on a Raspberry Pi. Also, each time the sensor updates (i.e. at each scan interval), anywhere from ~300B to ~25KB of data is consumed. Keep this in mind if you have a low internet data cap.
 
 ## Exposed Information
 The sensor will expose the status of the tracked team's scheduled game for the day. The state can be:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 # Home Assistant NHL API
 NHL Stats API Integration Into Home Assistant: Bring live score updates into Home Assistant and fire automations when your team scores!
 
-<span style="color:red">*New!*</span> The sensor will only fetch data every 10 minutes when the game is not live and will then update at the user defined frequency (or every second if undefined) once the game is live.
+<span style="color:red">*New!*</span> The sensor will only fetch data every 10 minutes when the game is not live and will then update at the user defined frequency (or every second if undefined) once the game is live. Credit goes to @mastermc0. 
 ## Installation: Manual
 1. Copy the `nhl_api` folder to the `custom_components` folder in your Home Assistant configuration directory.
 2. From the [teams.md](https://github.com/JayBlackedOut/hass-nhlapi/blob/master/teams.md) file in this repository, find the team_id of the team you would like to track.

--- a/custom_components/nhl_api/manifest.json
+++ b/custom_components/nhl_api/manifest.json
@@ -3,6 +3,6 @@
   "name": "NHL API",
   "documentation": "https://github.com/JayBlackedOut/hass-nhlapi",
   "dependencies": [],
-  "codeowners": ["@jayblackedout"],
+  "codeowners": ["@jayblackedout", "@mastermc0"],
   "requirements": ["pynhl==0.1.9"]
 }

--- a/custom_components/nhl_api/sensor.py
+++ b/custom_components/nhl_api/sensor.py
@@ -1,4 +1,4 @@
-"""
+""""
 Support for the undocumented NHL API.
 
 For more details about this platform, please refer to the documentation at
@@ -15,10 +15,11 @@ from homeassistant.const import (CONF_NAME, CONF_ID, CONF_SCAN_INTERVAL)
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.event import track_point_in_time
 
 _LOGGER = logging.getLogger(__name__)
 
-__version__ = '0.5.4'
+__version__ = '0.6.0dev'
 
 CONF_ID = 'team_id'
 CONF_NAME = 'name'
@@ -28,7 +29,9 @@ DEFAULT_NAME = 'NHL Sensor'
 LOGO_URL = 'https://www-league.nhlstatic.com/images/logos/'\
     'teams-current-primary-light/{}.svg'
 
-SCAN_INTERVAL = timedelta(seconds=5)
+PREGAME_SCAN_INTERVAL = timedelta(seconds=10)
+LIVE_SCAN_INTERVAL = timedelta(seconds=1)
+POSTGAME_SCAN_INTERVAL = timedelta(seconds=600)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ID, default=0): cv.positive_int,
@@ -40,21 +43,28 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the NHL API sensor."""
     team_id = config.get(CONF_ID)
     name = config.get(CONF_NAME, DEFAULT_NAME)
-    scan_interval = config.get(CONF_SCAN_INTERVAL, SCAN_INTERVAL)
-    add_entities([NHLSensor(team_id, name, scan_interval)], True)
+    add_entities([NHLSensor(team_id, name, hass)])
 
 
 class NHLSensor(Entity):
     """Representation of a NHL API sensor."""
 
-    def __init__(self, team_id, name, scan_interval):
+    def __init__(self, team_id, name, hass):
         """Initialize NHL API sensor."""
+        self.entity_id = "sensor." + name.replace(" ", "_").lower()
+        self.hass = hass
         self._state = None
-        self.team_id = team_id
+        self._team_id = team_id
         self._name = name
         self._icon = 'mdi:hockey-sticks'
-        self._scan_interval = scan_interval
+        self._last_scan = dt.today()
         self._state_attributes = {}
+        self.timer(dt.today())
+
+    @property
+    def should_poll(self):
+        """Polling not required."""
+        return False
 
     @property
     def name(self):
@@ -76,20 +86,27 @@ class NHLSensor(Entity):
         """Return the state attributes of the sensor."""
         return self._state_attributes
 
-    def update(self):
+    def timer(self, nowtime):
+        self.schedule_update_ha_state(True)
+        polling_delta = self.set_polling()
+        nexttime = nowtime + polling_delta
+        # Setup timer to run again at polling delta
+        track_point_in_time(self.hass, self.timer, nexttime)
+
+    def get_game_data(self):
         """Get the latest data from the NHL API via pynhl."""
-        games = Schedule(self.team_id).game_info()
-        dates = Schedule(self.team_id).datetime_info()
-        if Scoring(self.team_id).scoring_info() is not None:
-            plays = Scoring(self.team_id).scoring_info()
+        games = Schedule(self._team_id).game_info()
+        dates = Schedule(self._team_id).datetime_info()
+        if Scoring(self._team_id).scoring_info() is not None:
+            plays = Scoring(self._team_id).scoring_info()
         else:
             plays = {}
-        # Localize the UTC time values.
+        # Localize the returned UTC time values.
         if dates['next_game_datetime'] != "None":
             dttm = dt.strptime(dates['next_game_datetime'],
                                '%Y-%m-%dT%H:%M:%SZ')
             dttm_local = dt_util.as_local(dttm)
-            time = {'next_game_time': dttm_local.strftime('%-I:%M%p')}
+            time = {'next_game_time': dttm_local.strftime('%-I:%M %p')}
             # If next game is scheduled Today or Tomorrow,
             # return "Today" or "Tomorrow". Else, return
             # the actual date of the next game.
@@ -109,13 +126,18 @@ class NHLSensor(Entity):
             next_game_date = ''
         # Merge all attributes to a single dict.
         all_attr = {**games, **plays, **time, 'next_game_date': next_game_date}
-        # Set sensor state to game state.
-        # Display next game date and time if none today.
         next_date_time = game_date + " " + time['next_game_time']
-        if plays.get('game_state') == "Scheduled":
+        return all_attr, next_date_time
+
+    def set_state(self):
+        """Set sensor state to game state and set polling interval."""
+        all_attr = self.get_game_data()[0]
+        next_date_time = self.get_game_data()[1]
+        if all_attr.get('game_state') == "Scheduled":
+            # Display next game date and time if none today.
             self._state = next_date_time
         else:
-            self._state = plays.get('game_state', next_date_time)
+            self._state = all_attr.get('game_state', next_date_time)
         # Set sensor state attributes.
         self._state_attributes = all_attr
         # Set away team logo url as attribute 'away_logo'.
@@ -125,20 +147,38 @@ class NHLSensor(Entity):
         self._state_attributes['home_logo'] = \
             LOGO_URL.format(self._state_attributes.get('home_id'))
         # Set attribute for goal scored by tracked team.
-        if self._state_attributes.get('goal_team_id', None) == self.team_id:
+        if self._state_attributes.get('goal_team_id', None) == self._team_id:
             self._state_attributes['goal_tracked_team'] = True
         else:
             self._state_attributes['goal_tracked_team'] = False
-        # Fire the goal event handler.
+        # Send the event to the goal event handler.
         goal_team_id = self._state_attributes.get('goal_team_id', None)
         goal_event_id = self._state_attributes.get('goal_event_id', None)
         goal_event_handler(goal_team_id, goal_event_id, self.hass)
         # Clear the event list at game end.
         if self._state == "Game Over":
             event_list(0, True)
+        return self._state
+
+    def set_polling(self):
+        game_state = self._state
+        if game_state == "Pre-Game":
+            polling_delta = PREGAME_SCAN_INTERVAL
+        elif game_state in ("In Progress", "In Progress - Critical"):
+            polling_delta = LIVE_SCAN_INTERVAL
+        elif game_state in ("Game Over", "Final"):
+            polling_delta = POSTGAME_SCAN_INTERVAL
+        else:
+            polling_delta = POSTGAME_SCAN_INTERVAL
+        return polling_delta
+
+    def update(self):
+        """Update the sensor."""
+        self.set_state()
 
 
 def event_list(event_id=0, clear=False, lst=[]):
+    """Keep a list of goal event IDs returned by the API."""
     lst.append(event_id)
     lst = list(set(lst))
     if clear:
@@ -152,8 +192,7 @@ def goal_event_handler(goal_team_id, goal_event_id, hass):
     event_id = str(goal_event_id)
     # If the event hasn't yet been fired for this goal, fire it.
     # Else, add the event to the list anyway, in case the list is new.
-    if event_list() != [0] and \
-            event_id not in event_list():
+    if event_list() != [0] and event_id not in event_list():
         hass.bus.fire('nhl_goal', {"team_id": team_id})
         event_list(event_id)
     else:

--- a/custom_components/nhl_api/sensor.py
+++ b/custom_components/nhl_api/sensor.py
@@ -23,6 +23,7 @@ __version__ = '0.6.0dev'
 
 CONF_ID = 'team_id'
 CONF_NAME = 'name'
+CONF_SCAN_INTERVAL = 'scan_interval'
 
 DEFAULT_NAME = 'NHL Sensor'
 
@@ -36,6 +37,7 @@ POSTGAME_SCAN_INTERVAL = timedelta(seconds=600)
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Required(CONF_ID, default=0): cv.positive_int,
     vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_SCAN_INTERVAL): cv.positive_int,
 })
 
 
@@ -43,7 +45,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the NHL API sensor."""
     team_id = config.get(CONF_ID)
     name = config.get(CONF_NAME, DEFAULT_NAME)
-    scan_interval = config.get(CONF_SCAN_INTERVAL, LIVE_SCAN_INTERVAL)
+    scan_interval = config.get(timedelta(seconds=CONF_SCAN_INTERVAL), LIVE_SCAN_INTERVAL)
     add_entities([NHLSensor(team_id, name, scan_interval, hass)])
 
 

--- a/custom_components/nhl_api/sensor.py
+++ b/custom_components/nhl_api/sensor.py
@@ -11,7 +11,7 @@ from pynhl import Schedule, Scoring
 import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
-from homeassistant.const import CONF_NAME, CONF_ID, CONF_SCAN_INTERVAL
+from homeassistant.const import (CONF_NAME, CONF_ID, CONF_SCAN_INTERVAL)
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 from homeassistant.helpers.entity import Entity
@@ -19,37 +19,33 @@ from homeassistant.helpers.event import track_point_in_time
 
 _LOGGER = logging.getLogger(__name__)
 
-__version__ = "0.6.0dev"
+__version__ = '0.6.0dev'
 
-CONF_ID = "team_id"
-CONF_NAME = "name"
-CONF_SCAN_INTERVAL = "scan_interval"
+CONF_ID = 'team_id'
+CONF_NAME = 'name'
+CONF_SCAN_INTERVAL = 'scan_interval'
 
-DEFAULT_NAME = "NHL Sensor"
+DEFAULT_NAME = 'NHL Sensor'
 
-LOGO_URL = (
-    "https://www-league.nhlstatic.com/images/logos/"
-    "teams-current-primary-light/{}.svg"
-)
+LOGO_URL = 'https://www-league.nhlstatic.com/images/logos/'\
+    'teams-current-primary-light/{}.svg'
 
 PREGAME_SCAN_INTERVAL = timedelta(seconds=10)
 LIVE_SCAN_INTERVAL = timedelta(seconds=1)
 POSTGAME_SCAN_INTERVAL = timedelta(seconds=600)
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_ID, default=0): cv.positive_int,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-        vol.Optional(CONF_SCAN_INTERVAL): cv.positive_int,
-    }
-)
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
+    vol.Required(CONF_ID, default=0): cv.positive_int,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_SCAN_INTERVAL): cv.positive_int,
+})
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the NHL API sensor."""
     team_id = config.get(CONF_ID)
     name = config.get(CONF_NAME, DEFAULT_NAME)
-    scan_interval = config.get(CONF_SCAN_INTERVAL, LIVE_SCAN_INTERVAL)
+    scan_interval = config.get(CONF_SCAN_INTERVAL, LIVE_SCAN_INTERVAL.seconds)
     add_entities([NHLSensor(team_id, name, scan_interval, hass)])
 
 
@@ -63,8 +59,8 @@ class NHLSensor(Entity):
         self._state = None
         self._team_id = team_id
         self._name = name
-        self._scan_interval = timedelta(seconds=scan_interval)
-        self._icon = "mdi:hockey-sticks"
+        self._scan_interval = scan_interval
+        self._icon = 'mdi:hockey-sticks'
         self._last_scan = dt.today()
         self._state_attributes = {}
         self.timer(dt.today())
@@ -110,56 +106,58 @@ class NHLSensor(Entity):
         else:
             plays = {}
         # Localize the returned UTC time values.
-        if dates["next_game_datetime"] != "None":
-            dttm = dt.strptime(dates["next_game_datetime"], "%Y-%m-%dT%H:%M:%SZ")
+        if dates['next_game_datetime'] != "None":
+            dttm = dt.strptime(dates['next_game_datetime'],
+                               '%Y-%m-%dT%H:%M:%SZ')
             dttm_local = dt_util.as_local(dttm)
-            time = {"next_game_time": dttm_local.strftime("%-I:%M %p")}
+            time = {'next_game_time': dttm_local.strftime('%-I:%M %p')}
             # If next game is scheduled Today or Tomorrow,
             # return "Today" or "Tomorrow". Else, return
             # the actual date of the next game.
-            next_game_date = dttm_local.strftime("%B %-d, %Y")
+            next_game_date = dttm_local.strftime('%B %-d, %Y')
             now = dt_util.as_local(dt.now())
             pick = {
                 now.strftime("%Y-%m-%d"): "Today,",
-                (now + timedelta(days=1)).strftime("%Y-%m-%d"): "Tomorrow,",
+                (now + timedelta(days=1)).strftime("%Y-%m-%d"): "Tomorrow,"
             }
-            game_date = pick.get(dttm_local.strftime("%Y-%m-%d"), next_game_date)
+            game_date = pick.get(dttm_local.strftime("%Y-%m-%d"),
+                                 next_game_date)
         else:
-            time = {"next_game_time": ""}
-            game_date = "No Game Scheduled"
-            next_game_date = ""
+            time = {
+                'next_game_time': ''
+            }
+            game_date = 'No Game Scheduled'
+            next_game_date = ''
         # Merge all attributes to a single dict.
-        all_attr = {**games, **plays, **time, "next_game_date": next_game_date}
-        next_date_time = game_date + " " + time["next_game_time"]
+        all_attr = {**games, **plays, **time, 'next_game_date': next_game_date}
+        next_date_time = game_date + " " + time['next_game_time']
         return all_attr, next_date_time
 
     def set_state(self):
         """Set sensor state to game state and set polling interval."""
         all_attr = self.get_game_data()[0]
         next_date_time = self.get_game_data()[1]
-        if all_attr.get("game_state") == "Scheduled":
+        if all_attr.get('game_state') == "Scheduled":
             # Display next game date and time if none today.
             self._state = next_date_time
         else:
-            self._state = all_attr.get("game_state", next_date_time)
+            self._state = all_attr.get('game_state', next_date_time)
         # Set sensor state attributes.
         self._state_attributes = all_attr
         # Set away team logo url as attribute 'away_logo'.
-        self._state_attributes["away_logo"] = LOGO_URL.format(
-            self._state_attributes.get("away_id")
-        )
+        self._state_attributes['away_logo'] = \
+            LOGO_URL.format(self._state_attributes.get('away_id'))
         # Set home team logo url as attribute 'home_logo'.
-        self._state_attributes["home_logo"] = LOGO_URL.format(
-            self._state_attributes.get("home_id")
-        )
+        self._state_attributes['home_logo'] = \
+            LOGO_URL.format(self._state_attributes.get('home_id'))
         # Set attribute for goal scored by tracked team.
-        if self._state_attributes.get("goal_team_id", None) == self._team_id:
-            self._state_attributes["goal_tracked_team"] = True
+        if self._state_attributes.get('goal_team_id', None) == self._team_id:
+            self._state_attributes['goal_tracked_team'] = True
         else:
-            self._state_attributes["goal_tracked_team"] = False
+            self._state_attributes['goal_tracked_team'] = False
         # Send the event to the goal event handler.
-        goal_team_id = self._state_attributes.get("goal_team_id", None)
-        goal_event_id = self._state_attributes.get("goal_event_id", None)
+        goal_team_id = self._state_attributes.get('goal_team_id', None)
+        goal_event_id = self._state_attributes.get('goal_event_id', None)
         goal_event_handler(goal_team_id, goal_event_id, self.hass)
         # Clear the event list at game end.
         if self._state == "Game Over":
@@ -168,11 +166,11 @@ class NHLSensor(Entity):
 
     def set_polling(self):
         game_state = self._state
-        if game_state == "Pre-Game":
+        if game_state in (None, "Pre-Game"):
             polling_delta = PREGAME_SCAN_INTERVAL
         elif game_state in ("In Progress", "In Progress - Critical"):
-            if self._scan_interval > LIVE_SCAN_INTERVAL:
-                polling_delta = self._scan_interval
+            if timedelta(seconds=self._scan_interval) > LIVE_SCAN_INTERVAL:
+                polling_delta = timedelta(seconds=self._scan_interval)
             else:
                 polling_delta = LIVE_SCAN_INTERVAL
         else:
@@ -200,7 +198,7 @@ def goal_event_handler(goal_team_id, goal_event_id, hass):
     # If the event hasn't yet been fired for this goal, fire it.
     # Else, add the event to the list anyway, in case the list is new.
     if event_list() != [0] and event_id not in event_list():
-        hass.bus.fire("nhl_goal", {"team_id": team_id})
+        hass.bus.fire('nhl_goal', {"team_id": team_id})
         event_list(event_id)
     else:
         event_list(event_id)

--- a/custom_components/nhl_api/sensor.py
+++ b/custom_components/nhl_api/sensor.py
@@ -45,7 +45,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the NHL API sensor."""
     team_id = config.get(CONF_ID)
     name = config.get(CONF_NAME, DEFAULT_NAME)
-    scan_interval = config.get(timedelta(seconds=CONF_SCAN_INTERVAL), LIVE_SCAN_INTERVAL)
+    scan_interval = config.get(CONF_SCAN_INTERVAL, LIVE_SCAN_INTERVAL)
     add_entities([NHLSensor(team_id, name, scan_interval, hass)])
 
 
@@ -59,7 +59,7 @@ class NHLSensor(Entity):
         self._state = None
         self._team_id = team_id
         self._name = name
-        self._scan_interval = scan_interval
+        self._scan_interval = timedelta(seconds=scan_interval)
         self._icon = 'mdi:hockey-sticks'
         self._last_scan = dt.today()
         self._state_attributes = {}
@@ -173,8 +173,6 @@ class NHLSensor(Entity):
                 polling_delta = self._scan_interval
             else:
                 polling_delta = LIVE_SCAN_INTERVAL
-        elif game_state in ("Game Over", "Final"):
-            polling_delta = POSTGAME_SCAN_INTERVAL
         else:
             polling_delta = POSTGAME_SCAN_INTERVAL
         return polling_delta

--- a/info.md
+++ b/info.md
@@ -3,6 +3,8 @@
 ## Information:
 Track the score of your favorite NHL team and create automations based on your team scoring!
 
+<span style="color:red">*New!*</span> The sensor will only fetch data every 10 minutes when the game is not live and will then update at the user defined frequency (or every second if undefined) once the game is live.
+
 ## Usage:
 Add to configuration.yaml:
 


### PR DESCRIPTION
Based on PR #20 by @mastermc0 -- Cleaned up the code and added back user-defined scan_interval
* 10 minute scanning interval when game is not yet live
* 10 second scanning interval in pre-game
* 1 second default scanning interval while game is live
* User can define greater scanning interval for live game