### PR TITLE
Add goal_tracked_team boolean to goal_event data.

### DIFF
--- a/automations.md
+++ b/automations.md
@@ -7,6 +7,24 @@ As of Version 0.5.0, every time a goal is scored during a tracked game (i.e. a g
 
 The automation below will announce a Montreal Canadiens goal on the living room speaker with text-to-speech. Remember to wrap the team_id value in double-quotes or the automation will not fire.
 
+With the addition of `goal_tracked_team` to the goal_event data, you no longer have to code the goal_tracked team's ID into the trigger.
+
+```
+- alias: 'Montreal Goal Announcement'
+  trigger:
+    platform: event
+    event_type: nhl_goal
+    event_data:
+      goal_tracked_team: true
+  action:
+    service: tts.google_translate_say
+    entity_id: media_player.living_room_speaker
+    data:
+      message: 'The habs scored!'
+```
+
+Alternatively, you can still match against the team_id:
+
 ```
 - alias: 'Montreal Goal Announcement'
   trigger:
@@ -76,15 +94,15 @@ Announce that the away team has scored over text-to-speech. For example, if the 
   action:
   - service: input_number.set_value
     entity_id: numeric_input.away_score
-    data_template: 
+    data_template:
       value: "{{ states.sensor.away_team.state |int }}"
   - service: notify.alexa_media
     data:
-      target: 
+      target:
         - "Living room Dot"
       message: "{{ state_attr( 'sensor.away_team', 'friendly_name') }} score!"
-      data: 
-        type: "tts" 
+      data:
+        type: "tts"
 ```
 Announce that the home team has scored over text-to-speech. For example, if the Montreal Canadiens are the home team and they score, the tts would say "Montreal Canadiens score!":
 
@@ -98,14 +116,14 @@ Announce that the home team has scored over text-to-speech. For example, if the 
   action:
   - service: input_number.set_value
     entity_id: numeric_input.home_score
-    data_template: 
+    data_template:
       value: "{{ states.sensor.home_team.state |int }}"
   - service: notify.alexa_media
     data:
-      target: 
+      target:
         - "Living room Dot"
       message: "{{ state_attr( 'sensor.home_team', 'friendly_name') }} score!"
-      data: 
+      data:
         type: "tts"
 ```
 
@@ -117,7 +135,7 @@ Play a goal horn mp3 over a speaker when the tracked team scores. Here, we use a
   initial_state: true
   trigger:
     platform: template
-    value_template: "{{ states.sensor.away_team.state |int > states.numeric_input.away_score |int or 
+    value_template: "{{ states.sensor.away_team.state |int > states.numeric_input.away_score |int or
 states.sensor.home_team.state |int > states.numeric_input.home_score |int }}"
   condition:
     condition: template
@@ -144,9 +162,9 @@ Announce the final score over text-to-speech:
   action:
   - service: notify.alexa_media
     data:
-      target: 
+      target:
         - "Living room Dot"
       message: "Final Score: {{ state_attr( 'sensor.away_team', 'friendly_name') }} {{ states('sensor.away_team') }},, {{ state_attr( 'sensor.home_team', 'friendly_name') }}{{ states('sensor.home_team') }} !"
-      data: 
+      data:
         type: "tts"
 ```

--- a/custom_components/nhl_api/sensor.py
+++ b/custom_components/nhl_api/sensor.py
@@ -181,7 +181,7 @@ class NHLSensor(Entity):
         # Send the event to the goal event handler.
         goal_team_id = self._state_attributes.get('goal_team_id', None)
         goal_event_id = self._state_attributes.get('goal_event_id', None)
-        goal_event_handler(goal_team_id, goal_event_id, self.hass)
+        goal_event_handler(goal_team_id, goal_event_id, self._state_attributes['goal_tracked_team'], self.hass)
         # Clear the event list at game end.
         if self._state == "Game Over":
             event_list(0, True)
@@ -214,14 +214,14 @@ def event_list(event_id=0, clear=False, lst=[]):
     return lst
 
 
-def goal_event_handler(goal_team_id, goal_event_id, hass):
+def goal_event_handler(goal_team_id, goal_event_id, goal_tracked_team, hass):
     """Handle firing of the goal event."""
     team_id = str(goal_team_id)
     event_id = str(goal_event_id)
     # If the event hasn't yet been fired for this goal, fire it.
     # Else, add the event to the list anyway, in case the list is new.
     if event_list() != [0] and event_id not in event_list():
-        hass.bus.fire('nhl_goal', {"team_id": team_id})
+        hass.bus.fire('nhl_goal', {"team_id": team_id, "goal_tracked_team": goal_tracked_team})
         event_list(event_id)
     else:
         event_list(event_id)


### PR DESCRIPTION
So the reason I wanted a boolean in the goal_event data was because I didn't want to have to code in my teams ID more than in the integration configuration (think DRY). The reality is this is pretty nit picky, but does make the integration slightly more flexible and would eliminate a field if we wanted to create a blueprint for use with the integration.

Initially, I was having the goal_event trigger a check of sensor.nhl_sensor.goal_tracked_team. Sometimes this worked, but sometimes there was a race condition where the goal_event had been triggered, but sensor.nhl_sensor hadn't been updated. Let me tell you, when your house cheers for the wrong team's goal, it's pretty disappointing. Ultimately, including all the needed information in the goal_event data made this work 100% of the time.

I actually got this working last season, but never got a PR in, and with the season starting soon, I figured it was time. Happy to get feedback and make changes. 
Lets go Aves!