### PR TITLE
Remove deprecated device_state_attributes

### DIFF
--- a/custom_components/nhl_api/sensor.py
+++ b/custom_components/nhl_api/sensor.py
@@ -88,7 +88,7 @@ class NHLSensor(Entity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
         return self._state_attributes
 


### PR DESCRIPTION
Due to a change in HA 2021.12 :
home-assistant/core#47304
remove deprecated device_state_attributes in favor of extra_state_attributes.
Fixes #45

Tested and working locally on 2021.12.7