### PR TITLE
Expose Next Game DateTime as Attribute

### DIFF
--- a/custom_components/nhl_api/sensor.py
+++ b/custom_components/nhl_api/sensor.py
@@ -125,7 +125,7 @@ class NHLSensor(Entity):
             dttm = dt.strptime(dates['next_game_datetime'],
                                '%Y-%m-%dT%H:%M:%S%z')
             dttm_local = dt_util.as_local(dttm)
-            time = {'next_game_time': dttm_local.strftime('%-I:%M %p')}
+            time = {'next_game_time': dttm_local.strftime('%-I:%M %p'), 'next_game_datetime': dttm_local}
             # If next game is scheduled Today or Tomorrow,
             # return "Today" or "Tomorrow". Else, return
             # the actual date of the next game.


### PR DESCRIPTION
This adds a new attribute, "Next game datetime," which exposes the date and time of the next game in a single attribute. This is necessary if you want to have automations that rely on the start time. 

Probably not being defined in the best place (I am a neophyte at Python); maybe there's a better place for it to be placed?

Sample automation.yaml:
- id: leafsgamestart
  alias: Leafs Game Start
  trigger:
    - platform: state
      entity_id: sensor.leafs_game
      to: "Pre-Game"
  condition:
    - condition: time
      before: '18:30:00'
  action:
    - wait_template: "{{ as_timestamp(states('sensor.date_time_iso')) == as_timestamp(state_attr('sensor.leafs_game', 'next_game_datetime') - timedelta(minutes=5)) }}"
    - condition: state
      entity_id: input_select.tam_status
      state: 'Home'
    - service: media_extractor.play_media
      entity_id: media_player.all_speakers
      data:
        media_content_id: "https://www.youtube.com/watch?v=jkG2dLl0Gso"
        media_content_type: "audio/youtube"
    - delay: 56
    - service: media_extractor.play_media
      entity_id: media_player.all_speakers
      data:
        media_content_id: "https://www.youtube.com/watch?v=dwpqiaWKPkQ"
        media_content_type: "audio/youtube"