### PR TITLE
Poll OVER game state at live interval

### DIFF
--- a/custom_components/nhl_api/sensor.py
+++ b/custom_components/nhl_api/sensor.py
@@ -187,7 +187,7 @@ class NHLSensor(Entity):
         game_state = self._state
         if game_state == "PRE":
             polling_delta = PREGAME_SCAN_INTERVAL
-        elif game_state in [None, "LIVE", "CRIT"]:
+        elif game_state in [None, "LIVE", "CRIT", "OVER"]:
             if self._scan_interval > LIVE_SCAN_INTERVAL:
                 polling_delta = self._scan_interval
             else:


### PR DESCRIPTION
## Summary

Adds `"OVER"` to the list of game states that use the live scan interval in `NHLSensor.set_polling`.

## Motivation

When a game ends, the NHL API reports the `OVER` state before transitioning to `FINAL`/`OFF`. Currently, `OVER` falls through to the default (slow) scan interval, which delays the sensor picking up the final game state and post-game data. Polling `OVER` at the live interval keeps the sensor responsive during this transition window.

## Changes

- `sensor.py`: treat `OVER` like `LIVE`/`CRIT` for polling interval selection (one-line change).